### PR TITLE
Fix Translation for unlocks.unlocked message

### DIFF
--- a/rails/locales/pt-BR.yml
+++ b/rails/locales/pt-BR.yml
@@ -107,7 +107,7 @@ pt-BR:
         resend_unlock_instructions: Reenviar instruções de desbloqueio
       send_instructions: Dentro de minutos, você receberá um email com instruções de desbloqueio da sua conta.
       send_paranoid_instructions: Se sua conta existir em nosso banco de dados, você receberá em breve um email com instruções para desbloquear ela.
-      unlocked: A sua conta foi desbloqueada com sucesso. Você está autenticado.
+      unlocked: A sua conta foi desbloqueada com sucesso. Efetue login para continuar.
   errors:
     messages:
       already_confirmed: já foi confirmado


### PR DESCRIPTION
This meants to keep `devise.unlocks.unlocked` consistent with the English version:  
"Your account has been unlocked successfully. Please sign in to continue."